### PR TITLE
fix negative random number

### DIFF
--- a/main.py
+++ b/main.py
@@ -181,6 +181,7 @@ def modify_decimal_part(num):
     random_offset = random.randint(-15000, 15000)
     # 计算新的小数部分
     new_decimal_value = decimal_value + random_offset
+    new_decimal_value = abs(new_decimal_value)
     # 将新的小数部分转换为字符串，并确保它有3位
     new_decimal_str = f"{new_decimal_value:05d}"
     # 拼接回原浮点数


### PR DESCRIPTION
这里的随机数可能生成负数，负数作为字符串拼接之后得到的字符串，转换到小数格式，会报错。
ValueError: could not convert string to float: '119.527-1903'